### PR TITLE
Able to override the GEN value with optional secret

### DIFF
--- a/.github/workflows/check-and-publish.yml
+++ b/.github/workflows/check-and-publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 env:
-  GEN: "ws1"
+  GEN: ${{ secrets.GEN || 'ws1' }}
   APOLLO_KEY: ${{ vars.TOKEN }}
   
 jobs:

--- a/.github/workflows/create_studio_project.yml
+++ b/.github/workflows/create_studio_project.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 env:
-  GEN: "ws1"
+  GEN: ${{ secrets.GEN || 'ws1' }}
   APOLLO_KEY: ${{ secrets.APOLLO_USER_KEY }}
 
 jobs:

--- a/.github/workflows/deploy-router.yml
+++ b/.github/workflows/deploy-router.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 env:
-  GEN: "ws1"
+  GEN: ${{ secrets.GEN || 'ws1' }}
 
 jobs:
   deploy:

--- a/.github/workflows/publish-subgraph.yml
+++ b/.github/workflows/publish-subgraph.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 env:
-  GEN: "ws1"
+  GEN: ${{ secrets.GEN || 'ws1' }}
   APOLLO_KEY: ${{ vars.TOKEN }}
   
 jobs:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -7,7 +7,7 @@ on:
       - '**.yml'
 
 env:
-  GEN: ${{ secrets.GEN || 'ws1' }}
+  GEN: ${{ secrets.GEN || 'ws2' }}
 
 jobs:
   create:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -7,7 +7,7 @@ on:
       - '**.yml'
 
 env:
-  GEN: ${{ secrets.GEN || 'ws2' }}
+  GEN: ${{ secrets.GEN || 'ws1' }}
 
 jobs:
   create:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -7,7 +7,7 @@ on:
       - '**.yml'
 
 env:
-  GEN: "ws1"
+  GEN: ${{ secrets.GEN || "ws1" }}
 
 jobs:
   create:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -7,7 +7,7 @@ on:
       - '**.yml'
 
 env:
-  GEN: ${{ secrets.GEN || "ws1" }}
+  GEN: ${{ secrets.GEN || 'ws1' }}
 
 jobs:
   create:

--- a/.github/workflows/subgraph-check.yml
+++ b/.github/workflows/subgraph-check.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 env:
-  GEN: "ws1"
+  GEN: ${{ secrets.GEN || 'ws1' }}
   APOLLO_KEY: ${{ vars.TOKEN }}
   
 jobs:

--- a/.github/workflows/update-router.yml
+++ b/.github/workflows/update-router.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 env:
-  GEN: "ws1"
+  GEN: ${{ secrets.GEN || 'ws1' }}
 
 jobs:
   deploy:


### PR DESCRIPTION
**Problem**
When validating the workshop, you will initialize your graph within Studio. But if you are to delete the graph within studio, that graph ID won't be available anymore when you try to re-run the workshop due to soft deletes. This becomes more of a problem if workshop attendees do this themselves, and we have to revise the template file.

**Solution**
Support overriding the GEN variable to allow re-GEN on the fly.